### PR TITLE
Bugfix for check base dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 .*.sw[a-z]
 build/
 dist/
+bin/
+.classpath
+.project

--- a/src/jp/co/antenna/XfoJavaCtl/XfoObj.java
+++ b/src/jp/co/antenna/XfoJavaCtl/XfoObj.java
@@ -173,6 +173,13 @@ public class XfoObj {
 
 	    //System.out.println("file: " + f.getName());
 	    if (name.startsWith(dirNamePattern)) {
+
+	    // stop here and do next iteration if current AHF dir
+		// is not equal with the provided checkBaseDir
+		if(checkBaseDir != null && !f.getAbsolutePath().equals(checkBaseDir)) {
+			continue;
+		}
+
 		String versionString;
 		int version = 0;
 


### PR DESCRIPTION
Bugfix for the new `checkBaseDir` option in `checkForLatestUnixFormatterDirectory()`

If this piece of code is missing (as of now) the `for` loop in line 170 would just iterate over ALL directories and pick the latest in alphabetical order.

This would result in `checkForLatestUnixFormatterDirectory ("Mac OS X", "/usr/local/AHFormatterV62")` picking the 6.3 version because the `AHFormatter63` directory is the latter in alphabetical (ls) order.

Solution here is to continue iterating over the directory listing if the current dir path (`f`) does not match the `checkBaseDir` parameter.

---

Additional gitignore update for eclipse!
