### PR TITLE
Fix 'isWindows' boolean on Windows returning 'false'

### DIFF
--- a/src/jp/co/antenna/XfoJavaCtl/XfoObj.java
+++ b/src/jp/co/antenna/XfoJavaCtl/XfoObj.java
@@ -411,8 +411,10 @@ public class XfoObj {
 	this.specifiedFormatterInstallation = specifiedFormatterInstallation;
 	try {
 	    os = System.getProperty("os.name");
-	    if ((os == null) || os.equals(""))
-		throw new Exception();
+	    if ((os == null) || os.equals("")) {
+			throw new Exception();
+	    }
+	    isWindows = os.contains("Windows");
 	} catch (Exception e) {
 	    throw new XfoException(4, 0, "Could not determine OS");
 	}
@@ -450,7 +452,6 @@ public class XfoObj {
 
 		// check possible future versions of Formatter
 		if (axf_home == null  ||  axf_home.equals("")) {
-		    boolean isWindows = os.contains("Windows");
 		    String foundKey = "";
 		    int foundVersion = 0;
 


### PR DESCRIPTION
the `isWindows` boolean returns `false` on a Windows system in the context of the `setCustomFormatterLocationEnvironmentVariables()` method.

This is the fix for it.